### PR TITLE
Add expected api method in gherkin validations

### DIFF
--- a/src/test/features/Collection.feature
+++ b/src/test/features/Collection.feature
@@ -7,4 +7,4 @@ Feature: Collection API
 
   Scenario: requesting the collection using a specific involvedMaker will return objects only from the chosen agent
     Given I send a Collection request with the involvedMaker Rembrandt+van+Rijn
-    Then all the artObjects must be made by "Rembrandt van Rijn"
+    Then all the artObjects received in the Collection Response must be made by "Rembrandt van Rijn"

--- a/src/test/features/CollectionDetails.feature
+++ b/src/test/features/CollectionDetails.feature
@@ -4,4 +4,4 @@ Feature: Collection Details API
 
   Scenario: requesting the collection details from an art object will retrieve more details on that
     Given I send a Collection details request for the object SK-C-5
-    Then I receive one object with the id SK-C-5
+    Then I receive a CollectionDetails response for one object with the id SK-C-5

--- a/src/test/java/com/mmestre/steps/ValidationSteps.java
+++ b/src/test/java/com/mmestre/steps/ValidationSteps.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ValidationSteps {
-    @Then("all the artObjects must be made by {string}")
+    @Then("all the artObjects received in the Collection Response must be made by {string}")
     public void artObjectsMatchesMaker(String expectedMaker) {
         Response response = CollectionClient.getResponse();
         CollectionResponse collectionResponse = response.as(CollectionResponse.class);
@@ -29,7 +29,7 @@ public class ValidationSteps {
         assertAll("Not all the art objects matches the expected maker.", assertions);
     }
 
-    @Then("I receive one object with the id {word}")
+    @Then("I receive a CollectionDetails response for one object with the id {word}")
     public void artObjectMatchesId(String expectedId) {
         Response response = CollectionDetailsClient.getResponse();
         CollectionDetailsResponse collectionDetailsResponse = response.as(CollectionDetailsResponse.class);


### PR DESCRIPTION
* `ValidationSteps`: change the gherkin definitions to include the response of which API method will be evaluated.
* `Collection.feature`, `CollectionDetails.feature`: affected by the change described above.