### PR TITLE
fix_mvn_test_execute_cucumber

### DIFF
--- a/src/test/java/com/mmestre/RunCucumberTest.java
+++ b/src/test/java/com/mmestre/RunCucumberTest.java
@@ -5,11 +5,13 @@ import org.junit.platform.suite.api.IncludeEngines;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 
+import static io.cucumber.junit.platform.engine.Constants.FEATURES_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 
 @Suite
 @IncludeEngines("cucumber")
 @SelectPackages("com.mmestre")
 @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
+@ConfigurationParameter(key = FEATURES_PROPERTY_NAME, value = "src/test/features")
 public class RunCucumberTest {
 }


### PR DESCRIPTION
* `RunCucumberTest`: added the missing location of the feature files, as it is not the default one.