### PR TITLE
move_cucumber_to_integration_tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,23 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.version}</version>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <excludes>
+                                <exclude>none</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/com/mmestre/rijksmuseum/RunCucumberIT.java
+++ b/src/test/java/com/mmestre/rijksmuseum/RunCucumberIT.java
@@ -13,5 +13,5 @@ import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 @SelectPackages("com.mmestre.rijksmuseum")
 @ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty")
 @ConfigurationParameter(key = FEATURES_PROPERTY_NAME, value = "src/test/features")
-public class RunCucumberTest {
+public class RunCucumberIT {
 }


### PR DESCRIPTION
* `RunCucumberTest` ->` RunCucumberIT`: renamed to identify the cucumber runner as integration tests.
* `pom.xml`: enables the execution of integration tests through the surefire plugin.