### PR TITLE
move_bean_generation_to_clients

### DIFF
--- a/src/main/java/com/mmestre/rijksmuseum/client/CollectionClient.java
+++ b/src/main/java/com/mmestre/rijksmuseum/client/CollectionClient.java
@@ -1,5 +1,6 @@
 package com.mmestre.rijksmuseum.client;
 
+import com.mmestre.rijksmuseum.model.collection.CollectionResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import lombok.Getter;
@@ -14,5 +15,12 @@ public class CollectionClient extends RestClient {
         Map<String, String> curatedParams = getCuratedParams(parameters);
         RequestSpecification collectionRequest = getReqSpecification();
         response = collectionRequest.queryParams(curatedParams).get(String.format("/api/%s/collection", culture));
+    }
+
+    public static CollectionResponse getResponseAsBean() {
+        if (response == null) {
+            throw new NullPointerException("The CollectionClient must receive an answer before to get the value as java bean.");
+        }
+        return response.as(CollectionResponse.class);
     }
 }

--- a/src/main/java/com/mmestre/rijksmuseum/client/CollectionDetailsClient.java
+++ b/src/main/java/com/mmestre/rijksmuseum/client/CollectionDetailsClient.java
@@ -1,5 +1,6 @@
 package com.mmestre.rijksmuseum.client;
 
+import com.mmestre.rijksmuseum.model.details.CollectionDetailsResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import lombok.Getter;
@@ -14,5 +15,12 @@ public class CollectionDetailsClient extends RestClient {
         Map<String, String> curatedParams = getCuratedParams(parameters);
         RequestSpecification collectionRequest = getReqSpecification();
         response = collectionRequest.queryParams(curatedParams).get(String.format("/api/%s/collection/%s", culture, id));
+    }
+
+    public static CollectionDetailsResponse getResponseAsBean() {
+        if (response == null) {
+            throw new NullPointerException("The CollectionDetailsClient must receive an answer before to get the value as java bean.");
+        }
+        return response.as(CollectionDetailsResponse.class);
     }
 }

--- a/src/main/java/com/mmestre/rijksmuseum/client/CollectionImageClient.java
+++ b/src/main/java/com/mmestre/rijksmuseum/client/CollectionImageClient.java
@@ -1,5 +1,7 @@
 package com.mmestre.rijksmuseum.client;
 
+import com.mmestre.rijksmuseum.model.image.CollectionImageResponse;
+import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import lombok.Getter;
@@ -15,5 +17,12 @@ public class CollectionImageClient extends RestClient {
         Map<String, String> curatedParams = getCuratedParams(parameters);
         RequestSpecification collectionRequest = getReqSpecification();
         response = collectionRequest.queryParams(curatedParams).get(String.format("/api/%s/collection/%s/tiles", culture, id));
+    }
+
+    public static CollectionImageResponse getResponseAsBean() {
+        if (response == null) {
+            throw new NullPointerException("The CollectionImageClient must receive an answer before to get the value as java bean.");
+        }
+        return response.as(CollectionImageResponse.class, ObjectMapperType.GSON);
     }
 }

--- a/src/test/java/com/mmestre/rijksmuseum/steps/ValidationSteps.java
+++ b/src/test/java/com/mmestre/rijksmuseum/steps/ValidationSteps.java
@@ -3,12 +3,10 @@ package com.mmestre.rijksmuseum.steps;
 import com.mmestre.rijksmuseum.client.CollectionClient;
 import com.mmestre.rijksmuseum.client.CollectionDetailsClient;
 import com.mmestre.rijksmuseum.client.CollectionImageClient;
+import com.mmestre.rijksmuseum.model.collection.CollectionResponse;
 import com.mmestre.rijksmuseum.model.details.CollectionDetailsResponse;
 import com.mmestre.rijksmuseum.model.image.CollectionImageResponse;
-import com.mmestre.rijksmuseum.model.collection.CollectionResponse;
 import io.cucumber.java.en.Then;
-import io.restassured.mapper.ObjectMapperType;
-import io.restassured.response.Response;
 import org.junit.jupiter.api.function.Executable;
 
 import java.util.List;
@@ -19,8 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class ValidationSteps {
     @Then("all the artObjects received in the Collection Response must be made by {string}")
     public void artObjectsMatchesMaker(String expectedMaker) {
-        Response response = CollectionClient.getResponse();
-        CollectionResponse collectionResponse = response.as(CollectionResponse.class);
+        CollectionResponse collectionResponse = CollectionClient.getResponseAsBean();
         assertNotEquals(0, collectionResponse.getArtObjects().size(),
                 "There should be at least one art object to compare.");
         List<Executable> assertions = collectionResponse.getArtObjects().stream()
@@ -31,16 +28,14 @@ public class ValidationSteps {
 
     @Then("I receive a CollectionDetails response for one object with the id {word}")
     public void artObjectMatchesId(String expectedId) {
-        Response response = CollectionDetailsClient.getResponse();
-        CollectionDetailsResponse collectionDetailsResponse = response.as(CollectionDetailsResponse.class);
+        CollectionDetailsResponse collectionDetailsResponse = CollectionDetailsClient.getResponseAsBean();
         assertNotNull(collectionDetailsResponse.getArtObject(), "The response didn't include any art object.");
         assertEquals(expectedId, collectionDetailsResponse.getArtObject().getObjectNumber(), "The art object number doesn't match.");
     }
 
     @Then("I receive a collection image response with at least {int} image(s)")
     public void minimumImagesReceived(int minimumImages) {
-        Response response = CollectionImageClient.getResponse();
-        CollectionImageResponse collectionImageResponse = response.as(CollectionImageResponse.class, ObjectMapperType.GSON);
+        CollectionImageResponse collectionImageResponse = CollectionImageClient.getResponseAsBean();
         assertNotNull(collectionImageResponse, "The response couldn't been parsed to the CollectionImageResponse class.");
         assertNotNull(collectionImageResponse.getLevels(), "Then response didn't return a list of levels");
         int imagesReceived = collectionImageResponse.getLevels().size();


### PR DESCRIPTION
* `CollectionClient`, `CollectionDetailsClient`, `CollectionImageClient`: received the responsibility the convert the response to its corresponding bean.
* `ValidationSteps`: now relays on the clients to convert the response received from the API to the expected bean.