### PR TITLE
added_security_validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The test subject is in this case a Rijksmuseum REST api. This API provides acces
 * Museum URL: <https://www.rijksmuseum.nl/nl>
 * Museum API documentation: <https://data.rijksmuseum.nl/object-metadata/api/>
 
-## Technologies
+## Tech stack
 
 The technologies that are being in place in this project to test the API are the following:
 
@@ -18,12 +18,14 @@ The technologies that are being in place in this project to test the API are the
 * [JUnit 5](https://junit.org/junit5/)
 * [RestAssured](https://rest-assured.io/)
 * [Gson](https://github.com/google/gson)
+* [GitHub Actions](https://docs.github.com/en/actions)
+* [Cucumber reports](https://reports.cucumber.io)
 
 ## Tests implemented
 
-Currently only three test cases were implemented, as this exercise is only be designed to show the possibilities, but it is not trying to try to cover all the required scenarios.
+Currently only few test cases were implemented, as this exercise is only be designed to show the possibilities, but it is not trying to try to cover all the required scenarios.
 
-Those 3 scenarios are matching the examples provided by the API documentation at the beginning of July 2024.
+From those, 3 scenarios are matching the examples provided by the API documentation at the beginning of July 2024.
 
 ## Test reports
 

--- a/src/main/java/com/mmestre/rijksmuseum/client/CollectionClient.java
+++ b/src/main/java/com/mmestre/rijksmuseum/client/CollectionClient.java
@@ -12,9 +12,13 @@ public class CollectionClient extends RestClient {
     public static Response response;
 
     public void queryCollection(String culture, Map<String, String> parameters) {
-        Map<String, String> curatedParams = getCuratedParams(parameters);
+        Map<String, String> paramsWithKey = addKeyToTheParams(parameters);
+        queryCollectionWithoutKey(culture, paramsWithKey);
+    }
+
+    public void queryCollectionWithoutKey(String culture, Map<String, String> parameters) {
         RequestSpecification collectionRequest = getReqSpecification();
-        response = collectionRequest.queryParams(curatedParams).get(String.format("/api/%s/collection", culture));
+        response = collectionRequest.queryParams(parameters).get(String.format("/api/%s/collection", culture));
     }
 
     public static CollectionResponse getResponseAsBean() {
@@ -22,5 +26,21 @@ public class CollectionClient extends RestClient {
             throw new NullPointerException("The CollectionClient must receive an answer before to get the value as java bean.");
         }
         return response.as(CollectionResponse.class);
+    }
+
+    public void sendDifferentMethod(String apiMethod) {
+        Map<String, String> paramsWithKey = addKeyToTheParams(Map.of());
+        String culture = "nl";
+        RequestSpecification collectionRequest = getReqSpecification();
+        switch (apiMethod) {
+            case "POST" ->
+                    response = collectionRequest.queryParams(paramsWithKey).post(String.format("/api/%s/collection", culture));
+            case "PATCH" ->
+                    response = collectionRequest.queryParams(paramsWithKey).patch(String.format("/api/%s/collection", culture));
+            case "DELETE" ->
+                    response = collectionRequest.queryParams(paramsWithKey).delete(String.format("/api/%s/collection", culture));
+            default ->
+                    throw new UnsupportedOperationException(String.format("Method %s not implemented yet.", apiMethod));
+        }
     }
 }

--- a/src/main/java/com/mmestre/rijksmuseum/client/CollectionDetailsClient.java
+++ b/src/main/java/com/mmestre/rijksmuseum/client/CollectionDetailsClient.java
@@ -12,9 +12,9 @@ public class CollectionDetailsClient extends RestClient {
     public static Response response;
 
     public void queryCollectionDetails(String culture, String id, Map<String, String> parameters) {
-        Map<String, String> curatedParams = getCuratedParams(parameters);
+        Map<String, String> paramsWithKey = addKeyToTheParams(parameters);
         RequestSpecification collectionRequest = getReqSpecification();
-        response = collectionRequest.queryParams(curatedParams).get(String.format("/api/%s/collection/%s", culture, id));
+        response = collectionRequest.queryParams(paramsWithKey).get(String.format("/api/%s/collection/%s", culture, id));
     }
 
     public static CollectionDetailsResponse getResponseAsBean() {

--- a/src/main/java/com/mmestre/rijksmuseum/client/CollectionImageClient.java
+++ b/src/main/java/com/mmestre/rijksmuseum/client/CollectionImageClient.java
@@ -14,9 +14,9 @@ public class CollectionImageClient extends RestClient {
     public static Response response;
 
     public void queryCollectionDetails(String culture, String id, Map<String, String> parameters) {
-        Map<String, String> curatedParams = getCuratedParams(parameters);
+        Map<String, String> paramsWithKey = addKeyToTheParams(parameters);
         RequestSpecification collectionRequest = getReqSpecification();
-        response = collectionRequest.queryParams(curatedParams).get(String.format("/api/%s/collection/%s/tiles", culture, id));
+        response = collectionRequest.queryParams(paramsWithKey).get(String.format("/api/%s/collection/%s/tiles", culture, id));
     }
 
     public static CollectionImageResponse getResponseAsBean() {

--- a/src/main/java/com/mmestre/rijksmuseum/client/RestClient.java
+++ b/src/main/java/com/mmestre/rijksmuseum/client/RestClient.java
@@ -29,7 +29,7 @@ class RestClient {
         return RestAssured.given().urlEncodingEnabled(false);
     }
 
-    protected Map<String, String> getCuratedParams(Map<String, String> parameters) {
+    protected Map<String, String> addKeyToTheParams(Map<String, String> parameters) {
         Map<String, String> curatedParams = new HashMap<>();
         curatedParams.put("key", key);
         curatedParams.putAll(parameters);

--- a/src/test/features/content/Collection.feature
+++ b/src/test/features/content/Collection.feature
@@ -1,3 +1,4 @@
+@ContentValidation
 Feature: Collection API
 
   GET /api/[culture]/collection gives access to the collection with brief information about each object. The results are

--- a/src/test/features/content/CollectionDetails.feature
+++ b/src/test/features/content/CollectionDetails.feature
@@ -1,3 +1,4 @@
+@ContentValidation
 Feature: Collection Details API
 
   GET /api/[culture]/collection/[object-number] gives more details of an object. Object numbers can be obtained from the results given in the Collection API.

--- a/src/test/features/content/CollectionImage.feature
+++ b/src/test/features/content/CollectionImage.feature
@@ -1,3 +1,4 @@
+@ContentValidation
 Feature: Collection Image API
 
   GET /api/[culture]/collection/[object-number]/tiles gives all the information you need to show the image split up in

--- a/src/test/features/technical/CollectionSecurity.feature
+++ b/src/test/features/technical/CollectionSecurity.feature
@@ -1,0 +1,23 @@
+@SecurityValidation
+Feature: Collection API security measures
+
+  The Collection API only supports access through GET method using a valid key
+
+  Scenario: requesting the collection without a key must return error 401 unauthorized
+    Given I send a Collection request without key to the involvedMaker Rembrandt+van+Rijn
+    Then the Collection API must return status 401
+
+  Scenario: requesting the collection with a wrong key must return error 401 unauthorized
+    Given I send a Collection request without key using the following parameters:
+      | key           | AAAAAA             |
+      | involvedMaker | Rembrandt+van+Rijn |
+    Then the Collection API must return status 401
+
+  Scenario Outline: use the API method <method> must return error 405 method now allowed
+    Given I call the Collection API using the method <method>
+    Then the Collection API must return status 405
+    Scenarios:
+      | method |
+      | POST   |
+      | PATCH  |
+      | DELETE |

--- a/src/test/java/com/mmestre/rijksmuseum/steps/CollectionSteps.java
+++ b/src/test/java/com/mmestre/rijksmuseum/steps/CollectionSteps.java
@@ -3,6 +3,7 @@ package com.mmestre.rijksmuseum.steps;
 import com.mmestre.rijksmuseum.client.CollectionClient;
 import com.mmestre.rijksmuseum.client.CollectionDetailsClient;
 import com.mmestre.rijksmuseum.client.CollectionImageClient;
+import io.cucumber.datatable.DataTable;
 import io.cucumber.java.en.Given;
 
 import java.util.Map;
@@ -12,6 +13,24 @@ public class CollectionSteps {
     public void collectionByInvolvedMaker(String involvedMaker) {
         Map<String, String> parameters = Map.of("involvedMaker", involvedMaker);
         new CollectionClient().queryCollection("nl", parameters);
+    }
+
+    @Given("I send a Collection request without key to the involvedMaker {word}")
+    public void collectionByInvolvedMakerWithoutKey(String involvedMaker) {
+        Map<String, String> parameters = Map.of("involvedMaker", involvedMaker);
+        new CollectionClient().queryCollectionWithoutKey("nl", parameters);
+    }
+
+
+    @Given("I send a Collection request without key using the following parameters:")
+    public void collectionWithoutKey(DataTable table) {
+        Map<String,String> parameters = table.asMap();
+        new CollectionClient().queryCollectionWithoutKey("nl", parameters);
+    }
+
+    @Given("I call the Collection API using the method {word}")
+    public void collectionByMethod(String method) {
+        new CollectionClient().sendDifferentMethod(method);
     }
 
     @Given("I send a Collection details request for the object {word}")

--- a/src/test/java/com/mmestre/rijksmuseum/steps/ContentValidationSteps.java
+++ b/src/test/java/com/mmestre/rijksmuseum/steps/ContentValidationSteps.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ValidationSteps {
+public class ContentValidationSteps {
     @Then("all the artObjects received in the Collection Response must be made by {string}")
     public void artObjectsMatchesMaker(String expectedMaker) {
         CollectionResponse collectionResponse = CollectionClient.getResponseAsBean();

--- a/src/test/java/com/mmestre/rijksmuseum/steps/StatusValidationSteps.java
+++ b/src/test/java/com/mmestre/rijksmuseum/steps/StatusValidationSteps.java
@@ -1,0 +1,12 @@
+package com.mmestre.rijksmuseum.steps;
+
+import com.mmestre.rijksmuseum.client.CollectionClient;
+import io.cucumber.java.en.Then;
+
+public class StatusValidationSteps {
+
+    @Then("the Collection API must return status {int}")
+    public void checkCollectionStatus(int expectedStatus) {
+        CollectionClient.getResponse().then().statusCode(expectedStatus);
+    }
+}


### PR DESCRIPTION
* `CollectionClient`:
  * `queryCollectionWithoutKey():` added method to query without keys
  * `sendDifferentMethod()`: added method to trigger different API methods.
* `CollectionDetailsClient`, `CollectionImageClient`: Renamed internal variable to better represent its usage.
* `RestClient`: renamed `getCuratedParams()` to `addKeyToTheParams()` to better represent its responsibility.
* **Feature files**:
  * The existing files were moved to a separate folder. They also receive the tag `@ContentValidation`, to increase the result readability.
  * Added a new `CollectionSecurity` feature file to store the tests related to the behavior of the API in terms of security.
* `CollectionSteps`: added methods to receive requests from gherkin to call different methods from the API, and to receive custom parameters.
* `ValidationSteps` -> `ContentValidationSteps`: renamed to separate it from the validations from other type.
* `StatusValidationSteps`: added a step to validate the HTTP status received.
* `README.md`:
  * renamed Technologies to Tech stack
  * added missing GitHub Action and Cucumber reports as important tech stack in use.
  * updated the comment on the test implemented to mention there are more than 3 testCases now.