### PR TITLE
move_token

### DIFF
--- a/.github/workflows/mr_maven_verify.yml
+++ b/.github/workflows/mr_maven_verify.yml
@@ -20,13 +20,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the project
+        uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
+      - name: insert cucumber report token
+        env:
+          TOKEN: ${{ secrets.REPORT_TOKEN }}
+        run: echo "\n cucumber.publish.token=$TOKEN" >> ./src/test/resources/junit-platform.properties
       - name: Build with Maven
         env:
           API_KEY: ${{ secrets.API_KEY }}

--- a/.github/workflows/pr_maven_test.yml
+++ b/.github/workflows/pr_maven_test.yml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the project
+        uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/src/test/resources/junit-platform.properties
+++ b/src/test/resources/junit-platform.properties
@@ -1,2 +1,1 @@
 cucumber.publish.enabled=true
-cucumber.publish.token=27f089ed-4ed3-4a60-b4be-dc2cb9f28263


### PR DESCRIPTION
Remove the hardcoded token to publish cucumber reports.
* mr_maven_verify.yml: added a step to read the token from the secrets and store it in the junit-platform.properties file on the fly.
* junit-platform.properties: deleted the token from the file.