### PR TITLE
move_token

### DIFF
--- a/.github/workflows/mr_maven_verify.yml
+++ b/.github/workflows/mr_maven_verify.yml
@@ -31,7 +31,7 @@ jobs:
       - name: insert cucumber report token
         env:
           TOKEN: ${{ secrets.REPORT_TOKEN }}
-        run: echo "\n cucumber.publish.token=$TOKEN" >> ./src/test/resources/junit-platform.properties
+        run: echo "\ncucumber.publish.token=$TOKEN" >> ./src/test/resources/junit-platform.properties
       - name: Build with Maven
         env:
           API_KEY: ${{ secrets.API_KEY }}


### PR DESCRIPTION
Remove the hardcoded token to publish cucumber reports.
* mr_maven_verify.yml: removed unneeded space